### PR TITLE
chore: fix readme test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ renders as
 
 ## Testing
 
-Tests are stored in `tests` folder. Run them by executing `npm run test` (you have to have `babel-node` installed globally, `npm install -g babel-node`).
+Tests are stored in `tests` folder. Run them by executing `npm run test` (you have to have `babel-node` installed globally, `npm install -g babel-cli`).
 You can also run only one test file by running `npm run test:file path/to/test`.
 
 ## TODO


### PR DESCRIPTION
you need `babel-cli` package instead of `babel-node` (which doesn't exists)
@brabeji final
