### PR TITLE
fix(utils/validateByJsonSchema): array with errors changed to string …

### DIFF
--- a/src/utils/validateByJsonSchema.js
+++ b/src/utils/validateByJsonSchema.js
@@ -30,7 +30,10 @@ export default function (
 					{},
 					allErrs,
 					{
-						[errorPath]: [errorMessage],
+						[errorPath]: [errorPath].errorMessage ?
+							`${[errorPath].errorMessage} ${errorMessage}`
+							:
+							errorMessage,
 					}
 				);
 			}, {})


### PR DESCRIPTION
…until redux-form supports error arrays in normal way
